### PR TITLE
Ensure that on Windows Python always runs in unbuffered mode

### DIFF
--- a/windows/templates/run.cmd
+++ b/windows/templates/run.cmd
@@ -6,6 +6,7 @@ SET ENV=%ENV_DRIVE%%ENV_PATH%
 
 SET PATH=%PATH%;%ENV%\\python\\;%ENV%\\python\\Scripts
 SET PYTHONPATH=%ENV%\\python\\Lib
+SET PYTHONUNBUFFERED=1
 
 SET HOME=%ENV%
 


### PR DESCRIPTION
On Windows we do not run in unbuffered mode by default. Ensure we do it.
