### PR TITLE
Update Mercurial to v2.1 and introduce constants for version numbers

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -2,11 +2,14 @@
 
 MOZMILL_VERSION=$1
 
-VIRTUALENV_URL=https://bitbucket.org/ianb/virtualenv/raw/1.5.2/virtualenv.py
+MERCURIAL_VERSION=2.1
+PYTHON_VERSION=$(python -c "import sys;print sys.version[:3]")
+VIRTUALENV_VERSION=1.5.2
 
 ENV_DIR=mozmill-env
-PYTHON_VERSION=$(python -c "import sys;print sys.version[:3]")
 TARGET_ARCHIVE=$(dirname $(pwd))/$MOZMILL_VERSION-$(basename $(pwd)).zip
+
+VIRTUALENV_URL=https://bitbucket.org/ianb/virtualenv/raw/$VIRTUALENV_VERSION/virtualenv.py
 
 
 cleanup () {
@@ -32,7 +35,7 @@ if [ ! -n "${VIRTUAL_ENV:+1}" ]; then
 fi
 
 echo "Installing required Python modules"
-pip install --upgrade --global-option="--pure" mercurial==1.9.3
+pip install --upgrade --global-option="--pure" mercurial==$MERCURIAL_VERSION
 pip install --upgrade simplejson
 
 echo "Installing Mozmill $MOZMILL_VERSION"

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -2,11 +2,14 @@
 
 MOZMILL_VERSION=$1
 
-VIRTUALENV_URL=https://bitbucket.org/ianb/virtualenv/raw/1.5.2/virtualenv.py
+MERCURIAL_VERSION=2.1
+PYTHON_VERSION=$(python -c "import sys;print sys.version[:3]")
+VIRTUALENV_VERSION=1.5.2
 
 ENV_DIR=mozmill-env
-PYTHON_VERSION=$(python -c "import sys;print sys.version[:3]")
 TARGET_ARCHIVE=$(dirname $(pwd))/$MOZMILL_VERSION-$(basename $(pwd)).zip
+
+VIRTUALENV_URL=https://bitbucket.org/ianb/virtualenv/raw/$VIRTUALENV_VERSION/virtualenv.py
 
 
 cleanup () {
@@ -32,7 +35,7 @@ if [ ! -n "${VIRTUAL_ENV:+1}" ]; then
 fi
 
 echo "Installing required Python modules"
-pip install --upgrade --global-option="--pure" mercurial==1.9.3
+pip install --upgrade --global-option="--pure" mercurial==$MERCURIAL_VERSION
 pip install --upgrade simplejson
 
 echo "Installing Mozmill $MOZMILL_VERSION"

--- a/windows/build.py
+++ b/windows/build.py
@@ -11,9 +11,14 @@ import urllib
 import zipfile
 
 
-URL_MSYS = "http://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.11/MSYS-1.0.11.exe/download"
-URL_MINTTY = "http://mintty.googlecode.com/files/mintty-1.0.1-msys.zip"
-URL_VIRTUALENV = "https://bitbucket.org/ianb/virtualenv/raw/1.5.2/virtualenv.py"
+VERSION_MERCURIAL = "2.1"
+VERSION_MINTTY = "1.0.1"
+VERSION_MSYS = "1.0.11"
+VERSION_VIRTUALENV = "1.5.2"
+
+URL_MSYS = "http://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-%(VERSION)s/MSYS-%(VERSION)s.exe/download" % { 'VERSION' : VERSION_MSYS }
+URL_MINTTY = "http://mintty.googlecode.com/files/mintty-%s-msys.zip" % VERSION_MINTTY
+URL_VIRTUALENV = "https://bitbucket.org/ianb/virtualenv/raw/%s/virtualenv.py" % VERSION_VIRTUALENV
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 template_dir = os.path.join(base_dir, "templates")
@@ -95,7 +100,8 @@ make_relocatable("%s\\Scripts\\*.py" % (python_dir))
 
 print "Installing required Python modules"
 subprocess.check_call(["%s\\run.cmd" % env_dir, "pip", "install",
-                       "--upgrade", "--global-option='--pure'", "mercurial==1.9.3"])
+                       "--upgrade", "--global-option='--pure'",
+                       "mercurial==%s" % VERSION_MERCURIAL])
 subprocess.check_call(["%s\\run.cmd" % env_dir, "pip", "install",
                        "--upgrade", "mozmill==%s" % (mozmill_version)])
 make_relocatable("%s\\Scripts\\*.py" % (python_dir))


### PR DESCRIPTION
We are still using Mercurial 1.9.3 in our Mozmill environment. With 2.0 and 2.1 a lot of improvements have been introduced. So lets upgraded.

I have build environments locally and tested them on all platforms. I haven't found any regression in Mercurial.

Also this patch adds constants to the top of the files to ensure we can modify it way better in the future.
