### PR TITLE
Remove setup steps from Windows readme

### DIFF
--- a/windows/templates/readme.txt
+++ b/windows/templates/readme.txt
@@ -1,6 +1,6 @@
 Test environment for Mozmill test execution via the command line on Windows.
 
-Note: Configure the environment before the first use by running setup.cmd.
+
 
 Usage
 =====


### PR DESCRIPTION
Removed the following reference :

Note: Configure the environment before the first use by running setup.cmd.

From the following folder:

C:\Users\Admin\mozmill-environment\windows\templates.  As this reference to 'setup.cmd' is not required
