### PR TITLE
Update readme for windows, linux and macos (Fixes #35)

### DIFF
--- a/linux/templates/readme.txt
+++ b/linux/templates/readme.txt
@@ -1,10 +1,10 @@
 Test environment for Mozmill test execution via the command line on Linux.
 
 Usage
-====
+=====
 
 The run script can be used in interactive or scripted mode. For the latter,
 parameters have to be passed in.
 
-Manual:     . ./run
-Scripted:   ./run mozmill -b /usr/bin/firefox-bin -t ~/mozmill-tests/firefox
+Interactive:   . ./run
+Scripted:      ./run mozmill -b /usr/bin/firefox-bin -t ~/mozmill-tests/firefox

--- a/mac/templates/readme.txt
+++ b/mac/templates/readme.txt
@@ -1,10 +1,10 @@
 Test environment for Mozmill test execution via the command line on Mac.
 
 Usage
-====
+=====
 
 The run script can be used in interactive or scripted mode. For the latter,
 parameters have to be passed in.
 
-Manual:     . ./run
-Scripted:   ./run mozmill -b /Applications/Firefox.app -t ~/mozmill-tests/firefox
+Interactive:   . ./run
+Scripted:      ./run mozmill -b /Applications/Firefox.app -t ~/mozmill-tests/firefox

--- a/windows/templates/readme.txt
+++ b/windows/templates/readme.txt
@@ -1,11 +1,12 @@
 Test environment for Mozmill test execution via the command line on Windows.
 
-Note: Configure the environment before the first use by running setup.cmd.
-
 Usage
 =====
-The start script can be used manually or scripted. For the latter mode, parameters have to be passed in. The maximum number of allowed
-parameters is 9.
 
-Manual:   run.cmd
-Scripted: run.cmd mozmill -b c:\firefox\firefox.exe -t c:\mozmill-tests\firefox
+The run script can be used in interactive or scripted mode. For the latter,
+parameters have to be passed in.
+
+The maximum number of allowed parameters in scripted mode is 9.
+
+Interactive:   run.cmd
+Scripted:      run.cmd mozmill -b c:\(path to)\firefox.exe -t c:\mozmill-tests\firefox


### PR DESCRIPTION
Updated readme for windows, linux and macos for mozmill-environment. 

Windows
- Shortened the line lengths, reduced lines to under 80 characters. Added a generic implicit path in the usage example. Removed the 'setup.cmd' line that was the source of the original issue.

Tested with Notepad, Wordpad on windows, and also Vim on windows, to make sure it reads nicely on all readers, has no line wrap problems, and there are no other issues.

Linux/Mac
- Replaced the phrase 'Interactive' with 'Manual' so all 3 readme's use consistent terminology. Corrected what I believe to be an extra character in the usage example for manual: ". ./run" to "./run". I could be wrong, but I don't believe any unix command runs when preceded by dot.
