### PR TITLE
Adjust run.cmd to prepend python to PATH instead of append (#42)

### DIFF
--- a/windows/templates/run.cmd
+++ b/windows/templates/run.cmd
@@ -6,7 +6,7 @@ SET ENV_DRIVE=%~d0%
 SET ENV_PATH=%~p0%
 SET ENV=%ENV_DRIVE%%ENV_PATH%
 
-SET PATH=%PATH%;%ENV%\\python\\;%ENV%\\python\\Scripts
+SET PATH=%ENV%\\python\\;%ENV%\\python\\Scripts;%PATH%
 SET PYTHONPATH=%ENV%\\python\\Lib
 SET PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
This fix allows run.cmd on windows to successfully find mozmill-env's version of python, rather than the system's. In cases on windows where there was no python installed, it wasn't a problem; but on end-user systems with python installed, mozmill-environment testrun scripts were finding the system's version of python and so would fail.

Neither linux or macos were affected, their path order was fine.
