### PR TITLE
Add mozmill-automation package (#62)

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -42,7 +42,7 @@ if [ ! -n "${VIRTUAL_ENV:+1}" ]; then
     exit 1
 fi
 
-echo "Pre-installing Mercurial $VERSION_MERCURIAL in pure mode"
+echo "Pre-installing mercurial $VERSION_MERCURIAL in pure mode"
 pip install --upgrade --global-option="--pure" mercurial==$VERSION_MERCURIAL
 
 echo "Installing mozmill-automation $VERSION_MOZMILL_AUTOMATION and related packages"

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -42,7 +42,7 @@ if [ ! -n "${VIRTUAL_ENV:+1}" ]; then
     exit 1
 fi
 
-echo "Pre-installing Mercurial $VERSION_MERCURIAL in pure mode"
+echo "Pre-installing mercurial $VERSION_MERCURIAL in pure mode"
 pip install --upgrade --global-option="--pure" mercurial==$VERSION_MERCURIAL
 
 echo "Installing mozmill-automation $VERSION_MOZMILL_AUTOMATION and related packages"

--- a/windows/build.py
+++ b/windows/build.py
@@ -186,12 +186,12 @@ def main():
 
     run_cmd_path = os.path.join(dir_env, "run.cmd")
 
-    logging.info("Pre-installing Mercurial %s in pure mode" % VERSION_MERCURIAL)
+    logging.info("Pre-installing mercurial %s in pure mode" % VERSION_MERCURIAL)
     subprocess.check_call([run_cmd_path, "pip", "install",
                            "--upgrade", "--global-option='--pure'",
                            "mercurial==%s" % VERSION_MERCURIAL])
 
-    logging.info("Installing Mozmill-Automation %s and related packages" % mozmill_automation_version)
+    logging.info("Installing mozmill-automation %s and related packages" % mozmill_automation_version)
     subprocess.check_call([run_cmd_path, "pip", "install",
                            "--upgrade", "mozmill-automation==%s" %
                                mozmill_automation_version])


### PR DESCRIPTION
Ok, so that enables us to use the mozmill-automation package by pre-installing mercurial in pure mode. I have tested this across platforms but would like if some more people could test this. @davehunt, @andreeamatei, @jfrench, could all of you run some tests?  Once sourced into the environment the global 'testrun_*' should be available.
