### PR TITLE
Remove mozauto home directory during windows env build (#51)

### DIFF
--- a/windows/build.py
+++ b/windows/build.py
@@ -207,7 +207,7 @@ def main():
     remove_files(dir_python, "*.pyc")
     shutil.rmtree(os.path.join(dir_env, "build"), True)
 
-    logging.info("Deleting build account msys home directory")
+    logging.info("Deleting MSYS home directory")
     shutil.rmtree(os.path.join(dir_msys, 'home'))
 
     logging.info("Building zip archive of environment")


### PR DESCRIPTION
This pull request removes the unused build account's msys home directory as an exit op during the build.

I've tested this locally with my own windows builds and everything seems in order. I did a compare of the entire env tree produced, and confirmed that the only change as expected is the removal of msys /home.

I've asked others in the related issue to try running without the dir present to ensure no adverse effects. So far the feedback has been positive.

There may be scenarios where /home/(user) gets regenerated during use of the env, but if so, that should be ok since it is the user's account, not mozauto's.

Adding @whimboo @davehunt for visibility.
