### PR TITLE
Clean up quoting in windows build script

### DIFF
--- a/windows/build.py
+++ b/windows/build.py
@@ -106,7 +106,7 @@ def make_relocatable(filepath):
         for line in fileinput.input(a_file, inplace=1):
             if fileinput.isfirstline() and line.startswith('#!'):
                 # Only on Windows we have to set Python into unbuffered mode
-                print "#!python -u"
+                print '#!python -u'
             else:
                 print line,
 
@@ -120,61 +120,61 @@ def main():
     (options, args) = parser.parse_args()
 
     if not ctypes.windll.shell32.IsUserAnAdmin():
-        logging.error("Sorry, this script requires administrative privileges.")
+        logging.error('Sorry, this script requires administrative privileges.')
         sys.exit(126)
 
     if not args:
-        parser.error("Version of Mozmill-Automation to be installed is required as first parameter.")
+        parser.error('Version of Mozmill-Automation to be installed is required as first parameter.')
     mozmill_automation_version = args[0]
 
-    logging.info("Delete all possible existent folders")
+    logging.info('Deleting all possible existent folders')
     shutil.rmtree(dir_env, True)
 
     # Ensure we have a clean and existent temporary directory
     shutil.rmtree(dir_tmp, True)
     os.makedirs(dir_tmp)
 
-    logging.info("Downloading virtualenv %s" % VERSION_VIRTUALENV)
+    logging.info('Downloading virtualenv %s' % VERSION_VIRTUALENV)
     virtualenv_file = download(URL_VIRTUALENV + VERSION_VIRTUALENV,
                                os.path.join(dir_tmp, 'virtualenv.zip'))
     virtualenv_zip = zipfile.ZipFile(virtualenv_file)
     virtualenv_zip.extractall(dir_tmp)
     virtualenv_zip.close()
 
-    logging.info("Creating new virtual environment")
+    logging.info('Creating new virtual environment')
     virtualenv_script = os.path.join(dir_tmp,
                                      'virtualenv-%s' % VERSION_VIRTUALENV,
                                      'virtualenv.py')
     subprocess.check_call(['python', virtualenv_script, dir_env])
 
-    logging.info("Install 'MSYS' in unattended mode. Answer questions with 'y' and 'n'.")
+    logging.info("Installing 'MSYS' in unattended mode. Answer questions with 'y' and 'n'.")
     # See: http://www.jrsoftware.org/ishelp/index.php?topic=setupcmdline
     msys_file = os.path.join(dir_assets, 'msys_setup.exe')
     subprocess.check_call([msys_file, '/VERYSILENT', '/SP-', '/NOICONS',
                            '/DIR=%s' % (dir_msys)])
 
-    logging.info("Replace MSYS DLLs with memory rebased versions.")
+    logging.info('Replacing MSYS DLLs with memory rebased versions.')
     msys_dll_file = os.path.join(dir_assets, 'msys_dll.zip')
     msys_dll_zip = zipfile.ZipFile(msys_dll_file, 'r')
     msys_dll_zip.extractall(os.path.join(dir_msys, 'bin'))
     msys_dll_zip.close()
 
-    logging.info("Install 'mintty'")
+    logging.info("Installing 'mintty'")
     mintty_file = os.path.join(dir_assets, 'msys_mintty.zip')
     mintty_zip = zipfile.ZipFile(mintty_file, 'r')
     mintty_zip.extract('mintty.exe', os.path.join(dir_msys, 'bin'))
     mintty_zip.close()
 
-    logging.info("Copy template files into environment")
+    logging.info('Copying template files into environment')
     copytree(dir_template, dir_env, True)
 
-    logging.info("Copy Python installation (including pythonXX.dll into environment)")
+    logging.info('Copying Python installation (including pythonXX.dll into environment)')
     copytree(sys.prefix, os.path.join(dir_env, 'python'), True)
     dlls = glob.glob(os.path.join(os.environ['WINDIR'], 'system32', 'python*.dll'))
     for dll_file in dlls:
         shutil.copy(dll_file, dir_python)
 
-    logging.info("Reorganizing folder structure")
+    logging.info('Reorganizing folder structure')
     shutil.rmtree(os.path.join(dir_python, 'Lib', 'site-packages'), True)
     shutil.move(os.path.join(dir_env, 'Lib', 'site-packages'),
                 os.path.join(dir_python, 'Lib'))
@@ -187,12 +187,12 @@ def main():
 
     run_cmd_path = os.path.join(dir_env, 'run.cmd')
 
-    logging.info("Pre-installing mercurial %s in pure mode" % VERSION_MERCURIAL)
+    logging.info('Pre-installing mercurial %s in pure mode' % VERSION_MERCURIAL)
     subprocess.check_call([run_cmd_path, 'pip', 'install',
                            '--upgrade', "--global-option='--pure'",
                            'mercurial==%s' % VERSION_MERCURIAL])
 
-    logging.info("Installing mozmill-automation %s and related packages" % mozmill_automation_version)
+    logging.info('Installing mozmill-automation %s and related packages' % mozmill_automation_version)
     subprocess.check_call([run_cmd_path, 'pip', 'install',
                            '--upgrade', 'mozmill-automation==%s' %
                                mozmill_automation_version])
@@ -200,18 +200,18 @@ def main():
     make_relocatable(os.path.join(python_scripts_dir, '*.py'))
     make_relocatable(os.path.join(python_scripts_dir, 'hg'))
 
-    logging.info("Deleting easy_install and pip scripts")
+    logging.info('Deleting easy_install and pip scripts')
     for pattern in ('easy_install*', 'pip*'):
         remove_files(python_scripts_dir, pattern)
 
-    logging.info("Deleting pre-compiled Python modules and build folder")
+    logging.info('Deleting pre-compiled Python modules and build folder')
     remove_files(dir_python, '*.pyc')
     shutil.rmtree(os.path.join(dir_env, 'build'), True)
 
-    logging.info("Deleting MSYS home directory")
+    logging.info('Deleting MSYS home directory')
     shutil.rmtree(os.path.join(dir_msys, 'home'))
 
-    logging.info("Building zip archive of environment")
+    logging.info('Building zip archive of environment')
     target_archive = os.path.join(os.path.dirname(dir_base), '%s-windows' % mozmill_automation_version)
     shutil.make_archive(target_archive, 'zip', dir_base, os.path.basename(dir_env))
 


### PR DESCRIPTION
I noticed during separate work in issue https://github.com/whimboo/mozmill-environment/issues/51, the general quoting style in build.py for windows was a bit inconsistent. This pull request makes the file consistent, hopefully in the desired way based on my earlier approved work. Single quotes for internal strings, double quotes for customer-facing strings, and some other minor new line adjustments.

Adding @whimboo and @davehunt for visiblity.
